### PR TITLE
feat: transform lwm2m loudness into NoiseLevelObserved

### DIFF
--- a/internal/pkg/application/decorators/decorators.go
+++ b/internal/pkg/application/decorators/decorators.go
@@ -21,6 +21,10 @@ func Illuminance(illuminance float64, observedAt time.Time) entities.EntityDecor
 	return decorators.Number("illuminance", illuminance, properties.ObservedAt(FormatTime(observedAt)))
 }
 
+func NoiseLevel(noise float64, observedAt time.Time) entities.EntityDecoratorFunc {
+	return decorators.Number("noiseLevel", noise, properties.ObservedAt(FormatTime(observedAt)))
+}
+
 func PeopleCount(peopleCount float64, observedAt time.Time) entities.EntityDecoratorFunc {
 	return decorators.Number("peopleCount", peopleCount, properties.ObservedAt(FormatTime(observedAt)))
 }

--- a/internal/pkg/application/measurements/measurements.go
+++ b/internal/pkg/application/measurements/measurements.go
@@ -33,6 +33,7 @@ const (
 	ConductivityURN string = "urn:oma:lwm2m:ext:3327"
 	HumidityURN     string = "urn:oma:lwm2m:ext:3304"
 	IlluminanceURN  string = "urn:oma:lwm2m:ext:3301"
+	LoudnessURN     string = "urn:oma:lwm2m:ext:3324"
 	PeopleCountURN  string = "urn:oma:lwm2m:ext:3434"
 	PresenceURN     string = "urn:oma:lwm2m:ext:3302"
 	PressureURN     string = "urn:oma:lwm2m:ext:3323"
@@ -51,6 +52,7 @@ var (
 		HumidityURN + "/indoors":    IndoorEnvironmentObserved,
 		TemperatureURN + "/indoors": IndoorEnvironmentObserved,
 		TemperatureURN + "/air":     WeatherObserved,
+		LoudnessURN:                 NoiseLevelObserved,
 		PeopleCountURN + "/indoors": IndoorEnvironmentObserved,
 		ConductivityURN + "/soil":   GreenspaceRecord,
 		PressureURN + "/soil":       GreenspaceRecord,
@@ -282,6 +284,26 @@ func GreenspaceRecord(ctx context.Context, msg events.MessageAccepted, cbClient 
 	ctx = logging.NewContextWithLogger(ctx, logging.GetFromContext(ctx), slog.String("entity_id", id))
 
 	return cip.MergeOrCreate(ctx, cbClient, id, fiware.GreenspaceRecordTypeName, properties)
+}
+func NoiseLevelObserved(ctx context.Context, msg events.MessageAccepted, cbClient client.ContextBrokerClient) error {
+	const SensorValue int = 5700
+	noise, ok := msg.Pack().GetValue(finder(msg, LoudnessURN, SensorValue))
+	if !ok {
+		return ErrNoRelevantProperties
+	}
+
+	properties := []entities.EntityDecoratorFunc{
+		NoiseLevel(noise, timestamp(msg)),
+		decorators.DateObserved(msg.Timestamp.Format(time.RFC3339)),
+	}
+
+	if lat, lon, ok := msg.Pack().GetLatLon(); ok {
+		properties = append(properties, decorators.Location(lat, lon))
+	}
+
+	id := "urn:ngsi-ld:NoiseLevelObserved:" + msg.DeviceID()
+
+	return cip.MergeOrCreate(ctx, cbClient, id, "NoiseLevelObserved", properties)
 }
 
 func IndoorEnvironmentObserved(ctx context.Context, msg events.MessageAccepted, cbClient client.ContextBrokerClient) error {

--- a/internal/pkg/application/measurements/measurements_test.go
+++ b/internal/pkg/application/measurements/measurements_test.go
@@ -182,6 +182,36 @@ func TestThatIndoorEnvironmentObservedCanBeCreated(t *testing.T) {
 	is.True(strings.Contains(string(b), `"temperature":{"type":"Property","value":22.2,"observedAt":"2022-01-01T00:00:00Z"},"type":"IndoorEnvironmentObserved"}`))
 }
 
+func TestThatNoiseLevelObservedCanBeCreated(t *testing.T) {
+	noise := 58.0
+	is, cbClient := testSetup(t)
+	ti, _ := time.Parse(time.RFC3339, "2022-01-01T00:00:00Z")
+	msg := iotcore.NewMessageAccepted(senml.Pack{}, base("urn:oma:lwm2m:ext:3324", "deviceID", ti), iotcore.Lat(62.362829), iotcore.Lon(17.509804), iotcore.Rec("5700", "", &noise, nil, 0, nil))
+	msg.Timestamp = ti
+
+	err := NoiseLevelObserved(context.Background(), *msg, cbClient)
+	is.NoErr(err)
+	is.Equal(len(cbClient.MergeEntityCalls()), 1)
+
+	b, _ := json.Marshal(cbClient.CreateEntityCalls()[0].Entity)
+	is.True(strings.Contains(string(b), `"type":"NoiseLevelObserved"`))
+	is.True(strings.Contains(string(b), `"noiseLevel":{"type":"Property","value":58`))
+	is.True(strings.Contains(string(b), `"dateObserved":{"type":"Property","value":{"@type":"DateTime","@value":"2022-01-01T00:00:00Z"}}`))
+}
+
+func TestThatNoiseLevelObservedRequiresNoiseLevel(t *testing.T) {
+	is := is.New(t)
+
+	msg := iotcore.NewMessageAccepted(senml.Pack{}, base("urn:oma:lwm2m:ext:3324", "deviceID", time.Now().UTC()))
+
+	cbClient := &client.ContextBrokerClientMock{}
+	err := NoiseLevelObserved(context.Background(), *msg, cbClient)
+
+	is.Equal(err, ErrNoRelevantProperties)
+	is.Equal(len(cbClient.MergeEntityCalls()), 0)
+	is.Equal(len(cbClient.CreateEntityCalls()), 0)
+}
+
 /*
 	func TestThatLifebuoyCanBeCreated(t *testing.T) {
 		p := true


### PR DESCRIPTION
Adds support for LwM2M object `3324` in `message.accepted` and transforms it into a FIWARE `NoiseLevelObserved`
  entity.